### PR TITLE
Make migrations and seeders skeleton compliant with Airbnb tslint

### DIFF
--- a/lib/assets/migrations/skeleton.ts
+++ b/lib/assets/migrations/skeleton.ts
@@ -1,7 +1,7 @@
 import { QueryInterface, SequelizeStatic } from 'sequelize';
 
 export = {
-  up: (queryInterface: QueryInterface, Sequelize: SequelizeStatic) => {
+  up: (queryInterface: QueryInterface, sequelize: SequelizeStatic) => {
     /*
       Add altering commands here.
       Return a promise to correctly handle asynchronicity.
@@ -11,7 +11,7 @@ export = {
     */
   },
 
-  down: (queryInterface: QueryInterface, Sequelize: SequelizeStatic) => {
+  down: (queryInterface: QueryInterface, sequelize: SequelizeStatic) => {
     /*
       Add reverting commands here.
       Return a promise to correctly handle asynchronicity.
@@ -19,5 +19,5 @@ export = {
       Example:
       return queryInterface.dropTable('users');
     */
-  }
+  },
 };

--- a/lib/assets/seeders/skeleton.ts
+++ b/lib/assets/seeders/skeleton.ts
@@ -1,7 +1,7 @@
 import { QueryInterface, SequelizeStatic } from 'sequelize';
 
 export = {
-  up: (queryInterface: QueryInterface, Sequelize: SequelizeStatic) => {
+  up: (queryInterface: QueryInterface, sequelize: SequelizeStatic) => {
     /*
       Add altering commands here.
       Return a promise to correctly handle asynchronicity.
@@ -14,7 +14,7 @@ export = {
     */
   },
 
-  down: (queryInterface: QueryInterface, Sequelize: SequelizeStatic) => {
+  down: (queryInterface: QueryInterface, sequelize: SequelizeStatic) => {
     /*
       Add reverting commands here.
       Return a promise to correctly handle asynchronicity.
@@ -22,5 +22,5 @@ export = {
       Example:
       return queryInterface.bulkDelete('Person', null, {});
     */
-  }
+  },
 };


### PR DESCRIPTION
This PR makes minor modifications on the skeleton to make them compliant with the Airbnb lint standard.