### PR TITLE
Make the migration skeleton even shorter

### DIFF
--- a/src/assets/migrations/skeleton.ts
+++ b/src/assets/migrations/skeleton.ts
@@ -1,7 +1,7 @@
 import { QueryInterface, SequelizeStatic } from 'sequelize';
 
 export = {
-  up: (queryInterface: QueryInterface, Sequelize: SequelizeStatic) => {
+  up(queryInterface: QueryInterface, Sequelize: SequelizeStatic) {
     /*
       Add altering commands here.
       Return a promise to correctly handle asynchronicity.
@@ -11,7 +11,7 @@ export = {
     */
   },
 
-  down: (queryInterface: QueryInterface, Sequelize: SequelizeStatic) => {
+  down(queryInterface: QueryInterface, Sequelize: SequelizeStatic) {
     /*
       Add reverting commands here.
       Return a promise to correctly handle asynchronicity.


### PR DESCRIPTION
This PR makes the migration skeleton even shorter by removing the function arrow syntax and using object function syntax.